### PR TITLE
Fix compatibily issue with Allegro CL Modern mode

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -8,7 +8,7 @@
 
 (defparameter *element-type* '(unsigned-byte 8))
 
-(defparameter *dummy-vector* (make-array 1 :element-type 'string :adjustable T :fill-pointer 0))
+(defparameter *dummy-vector* (make-array 1 :element-type 'string :adjustable t :fill-pointer 0))
 ;; Struct for containing sheet information
 (defstruct sheet
   (unique-strings *dummy-vector*
@@ -78,7 +78,7 @@
             sheet-struct
             ))))))
 
-(defmacro with-open-excel-sheet ((pathname sheet-index sheet-symbol &optional (silent T)) &body body)
+(defmacro with-open-excel-sheet ((pathname sheet-index sheet-symbol &optional (silent t)) &body body)
   "Open excel sheet, and execute body. Sheet struct is bound to sheet-symbol"
   (let ((result-var (gensym "result-")))
     `(let* ((,sheet-symbol (read-sheet ,pathname ,sheet-index :silent ,silent))
@@ -89,7 +89,7 @@
        ,result-var)))
 
 ;; similar but uses all sheets
-(defmacro with-all-excel-sheets ((pathname sheet-symbol index-symbol name-symbol &optional (silent T)) &body body)
+(defmacro with-all-excel-sheets ((pathname sheet-symbol index-symbol name-symbol &optional (silent t)) &body body)
   "For every sheet in excel file, execute body. Sheet struct is bound to sheet-symbol.
    Sheet index is bound to index-symbol.
    Sheet name is bound to name-symbol"
@@ -322,7 +322,7 @@
 ;; simple helper
 (defun sheet-first-row (sheet-struct)
   "Obtain first row of sheet"
-  (car (process-sheet sheet-struct :max-row 1 :silent T)))
+  (car (process-sheet sheet-struct :max-row 1 :silent t)))
 
 
 ;; helper for column info

--- a/src/metadata.lisp
+++ b/src/metadata.lisp
@@ -27,7 +27,7 @@
   "Retrieves VECTOR  of unique strings used on the file. Will be used later for retrieving string values from the xlsx file."
   (let ((vector (make-array *initial-unique-strings-array-size* :element-type 'string
                                                                 :fill-pointer 0
-                                                                :adjustable T)))
+                                                                :adjustable t)))
     (loop for str in (xmls:xmlrep-find-child-tags :si (get-entry "xl/sharedStrings.xml" zip))
           for x = (xmls:xmlrep-find-child-tag :t str)
           do

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -3,7 +3,7 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *regex* (cl-ppcre:create-scanner "^[A-Z]+"
                                                  :case-insensitive-mode nil
-                                                 :single-line-mode T)
+                                                 :single-line-mode t)
     "Regex to capture column number (alphanumerical, i.e. 'AA')"))
 
 (defun get-column-label (str)


### PR DESCRIPTION
Change the symbol T to lower case t, this trivial change allow lisp-xl
to run successfully under Allegro CL Modern mode (see
http://franz.com/support/documentation/current/doc/case.htm).